### PR TITLE
refactor: use TavilySearchResults for domain lookup

### DIFF
--- a/src/enrichment.py
+++ b/src/enrichment.py
@@ -12,12 +12,13 @@ import requests
 from bs4 import BeautifulSoup
 from dotenv import load_dotenv
 from langchain.prompts import PromptTemplate
+from langchain_community.tools.tavily_search import TavilySearchResults
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.tools import tool
 
 # LangChain imports for AI-driven extraction
 from langchain_openai import ChatOpenAI
-from langchain_tavily import TavilyCrawl, TavilyExtract, TavilySearch
+from langchain_tavily import TavilyCrawl, TavilyExtract
 from langgraph.graph import END, StateGraph
 from psycopg2.extras import Json
 
@@ -50,7 +51,7 @@ ZB_CACHE: dict[str, dict] = {}
 
 # Initialize Tavily clients (optional). If no API key, skip Tavily and rely on fallbacks.
 if TAVILY_API_KEY:
-    tavily_search = TavilySearch(api_key=TAVILY_API_KEY)
+    tavily_search = TavilySearchResults(tavily_api_key=TAVILY_API_KEY)
     tavily_crawl = TavilyCrawl(api_key=TAVILY_API_KEY)
     tavily_extract = TavilyExtract(api_key=TAVILY_API_KEY)
 else:

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -9,7 +9,7 @@ from src import enrichment
 
 class DummySearch:
     def __init__(self, results):
-        self._results = {"results": results}
+        self._results = results
         self.last_query = None
 
     def run(self, query):


### PR DESCRIPTION
## Summary
- switch enrichment module to TavilySearchResults so search results include URLs
- update tests to use new search tool output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad84dc9d008320ac1f70eaf48d1a0d