### PR TITLE
Switch to langchain_tavily TavilySearch tool

### DIFF
--- a/src/enrichment.py
+++ b/src/enrichment.py
@@ -50,7 +50,7 @@ ZB_CACHE: dict[str, dict] = {}
 
 # Initialize Tavily clients (optional). If no API key, skip Tavily and rely on fallbacks.
 if TAVILY_API_KEY:
-    tavily_search = TavilySearch(api_key=TAVILY_API_KEY)
+    tavily_search = TavilySearch(max_results=5)
     tavily_crawl = TavilyCrawl(api_key=TAVILY_API_KEY)
     tavily_extract = TavilyExtract(api_key=TAVILY_API_KEY)
 else:

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -9,12 +9,12 @@ from src import enrichment
 
 class DummySearch:
     def __init__(self, results):
-        self._results = {"results": results}
+        self._results = results
         self.last_query = None
 
     def run(self, query):
         self.last_query = query
-        return self._results
+        return {"results": self._results}
 
 
 def test_find_domain_allows_aggregator_when_name_matches_apex(monkeypatch):


### PR DESCRIPTION
## Summary
- replace deprecated TavilySearchResults with TavilySearch from langchain_tavily
- adjust domain lookup to use new tool and update tests for new return format

## Testing
- `isort src/enrichment.py tests/test_enrichment.py`
- `black src/enrichment.py tests/test_enrichment.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad84dc9d008320ac1f70eaf48d1a0d