### PR TITLE
fix: support separate Odoo DSN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ LANGSMITH_API_KEY=""
 LANGSMITH_PROJECT="Nexius-Lead-Management"
 
 
-# single DSN used by both app & OdooStore
-POSTGRES_DSN=postgres://odoo_rw:secret@127.0.0.1:5432/odoo_db
+# Application database DSN
+POSTGRES_DSN=postgres://app_rw:secret@127.0.0.1:5432/app_db
+# Odoo database DSN (falls back to POSTGRES_DSN if unset)
+ODOO_POSTGRES_DSN=postgres://odoo_rw:secret@127.0.0.1:5432/odoo_db
 # DATABASE_URL is deprecated; use POSTGRES_DSN
 DATABASE_URL=
 ICP_RULE_NAME=

--- a/src/settings.py
+++ b/src/settings.py
@@ -13,8 +13,8 @@ load_dotenv(_SRC_DIR / ".env")
 
 # Database DSN (postgres://user:pass@host:port/db)
 POSTGRES_DSN = os.getenv("POSTGRES_DSN")
-# Single source: both “app” and “odoo” use the same DSN
-ODOO_POSTGRES_DSN = POSTGRES_DSN
+# Odoo can use its own DSN; falls back to POSTGRES_DSN if unset
+ODOO_POSTGRES_DSN = os.getenv("ODOO_POSTGRES_DSN") or POSTGRES_DSN
 APP_POSTGRES_DSN = POSTGRES_DSN
 
 # OpenAI / LangChain config


### PR DESCRIPTION
## Summary
- allow Odoo to use its own database connection string via `ODOO_POSTGRES_DSN`
- adjust migration script to read `ODOO_POSTGRES_DSN` and clarify error message
- document `ODOO_POSTGRES_DSN` in `.env.example`

## Testing
- `isort -v --check scripts/run_odoo_migration.py src/settings.py`
- `black scripts/run_odoo_migration.py src/settings.py`
- `ODOO_POSTGRES_DSN=postgresql://user:pass@localhost:1/db python scripts/run_odoo_migration.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc01de288320b50678e7336e1223