### PR TITLE
fix: support separate Odoo DSN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@ LANGSMITH_API_KEY=""
 LANGSMITH_PROJECT="Nexius-Lead-Management"
 
 
-# single DSN used by both app & OdooStore
-POSTGRES_DSN=postgres://odoo_rw:secret@127.0.0.1:5432/odoo_db
+# Application database DSN
+POSTGRES_DSN=postgres://app_rw:secret@127.0.0.1:5432/app_db
+# Odoo database DSN (falls back to POSTGRES_DSN if unset)
+ODOO_POSTGRES_DSN=postgres://odoo_rw:secret@127.0.0.1:5432/odoo_db
 # DATABASE_URL is deprecated; use POSTGRES_DSN
 DATABASE_URL=
 ICP_RULE_NAME=

--- a/scripts/run_odoo_migration.py
+++ b/scripts/run_odoo_migration.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from urllib.parse import urlparse, urlunparse
+
 import psycopg2
 
 # Ensure project root is on sys.path so we can import src.settings
@@ -8,23 +10,48 @@ if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
 try:
-    from src.settings import POSTGRES_DSN  # type: ignore
+    from src.settings import ODOO_POSTGRES_DSN  # type: ignore
 except Exception as e:
-    print("ERROR: Could not import POSTGRES_DSN from src/settings.py:", e)
+    print("ERROR: Could not import ODOO_POSTGRES_DSN from src/settings.py:", e)
     sys.exit(1)
 
 MIGRATION_FILE = os.path.join(ROOT, "app", "migrations", "001_presdr_odoo.sql")
 
 
+def _mask_dsn(dsn: str) -> str:
+    """Return DSN with password stripped for display."""
+    try:
+        parts = urlparse(dsn)
+        if "@" in parts.netloc and ":" in parts.netloc.split("@")[0]:
+            user, _ = parts.netloc.split("@")[0].split(":", 1)
+            host = parts.netloc.split("@", 1)[1]
+            netloc = f"{user}:***@{host}"
+        else:
+            netloc = parts.netloc
+        return urlunparse(
+            (
+                parts.scheme,
+                netloc,
+                parts.path,
+                parts.params,
+                parts.query,
+                parts.fragment,
+            )
+        )
+    except Exception:
+        return "<hidden>"
+
+
 def main():
-    if not POSTGRES_DSN:
-        print("ERROR: POSTGRES_DSN not set in environment/.env")
+    if not ODOO_POSTGRES_DSN:
+        print("ERROR: ODOO_POSTGRES_DSN not set in environment/.env")
         sys.exit(1)
     if not os.path.exists(MIGRATION_FILE):
         print(f"ERROR: Migration file not found: {MIGRATION_FILE}")
         sys.exit(1)
 
-    conn = psycopg2.connect(dsn=POSTGRES_DSN)
+    print("Using Odoo Postgres DSN:", _mask_dsn(ODOO_POSTGRES_DSN))
+    conn = psycopg2.connect(dsn=ODOO_POSTGRES_DSN)
     try:
         with conn:
             with conn.cursor() as cur:
@@ -39,7 +66,7 @@ def main():
                           WHERE c.relkind = 'r' AND c.relname = %s
                         );
                         """,
-                        (name,)
+                        (name,),
                     )
                     return bool(cur.fetchone()[0])
 
@@ -49,12 +76,17 @@ def main():
                 if not (has_res_partner and has_crm_lead):
                     print("\n❌ Odoo core tables not found in the target database.")
                     print("   Expected tables: res_partner, crm_lead")
-                    print("   Current DSN:", POSTGRES_DSN)
+                    print("   Current DSN:", _mask_dsn(ODOO_POSTGRES_DSN))
                     print("\nAction needed:")
-                    print(" - Point POSTGRES_DSN in your .env to the actual Odoo Postgres database.")
-                    print(" - Ensure the Odoo server has initialized its schema (start Odoo once).\n")
+                    print(
+                        " - Point ODOO_POSTGRES_DSN in your .env to the actual Odoo Postgres database."
+                    )
+                    print(
+                        " - Ensure the Odoo server has initialized its schema (start Odoo once).\n"
+                    )
                     sys.exit(2)
 
+                print("✅ Odoo core tables verified")
                 print(f"Applying Odoo migration: {MIGRATION_FILE}")
                 with open(MIGRATION_FILE, "r", encoding="utf-8") as f:
                     sql = f.read()

--- a/src/settings.py
+++ b/src/settings.py
@@ -13,8 +13,8 @@ load_dotenv(_SRC_DIR / ".env")
 
 # Database DSN (postgres://user:pass@host:port/db)
 POSTGRES_DSN = os.getenv("POSTGRES_DSN")
-# Single source: both “app” and “odoo” use the same DSN
-ODOO_POSTGRES_DSN = POSTGRES_DSN
+# Odoo can use its own DSN; falls back to POSTGRES_DSN if unset
+ODOO_POSTGRES_DSN = os.getenv("ODOO_POSTGRES_DSN") or POSTGRES_DSN
 APP_POSTGRES_DSN = POSTGRES_DSN
 
 # OpenAI / LangChain config


### PR DESCRIPTION
## Summary
- allow Odoo to use its own database connection string via `ODOO_POSTGRES_DSN`
- adjust migration script to read `ODOO_POSTGRES_DSN` and clarify error message
- document `ODOO_POSTGRES_DSN` in `.env.example`
- display masked DSN and explicit success output during migration

## Testing
- `isort -v --check scripts/run_odoo_migration.py src/settings.py .env.example`
- `black scripts/run_odoo_migration.py src/settings.py`
- `ODOO_POSTGRES_DSN=postgresql://user:pass@localhost:1/db python scripts/run_odoo_migration.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc01de288320b50678e7336e1223