### PR TITLE
feat: support ssh tunnel for odoo migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,22 @@ LANGSMITH_API_KEY=""
 LANGSMITH_PROJECT="Nexius-Lead-Management"
 
 
-# single DSN used by both app & OdooStore
-POSTGRES_DSN=postgres://odoo_rw:secret@127.0.0.1:5432/odoo_db
+# Application database DSN
+POSTGRES_DSN=postgres://app_rw:secret@127.0.0.1:5432/app_db
+# Odoo database DSN (configure separately)
+# Example points to a tunneled droplet database
+ODOO_POSTGRES_DSN=postgresql://odoo:odoo@localhost:25060/demo
+# Optional SSH tunnel variables to reach the droplet
+SSH_HOST=188.166.183.13
+SSH_PORT=22
+SSH_USER=root
+SSH_PASSWORD=My_password
+DB_HOST_IN_DROPLET=172.18.0.2
+DB_PORT=5432
+DB_NAME=demo
+DB_USER=odoo
+DB_PASSWORD=odoo
+LOCAL_PORT=25060
 # DATABASE_URL is deprecated; use POSTGRES_DSN
 DATABASE_URL=
 ICP_RULE_NAME=

--- a/app/odoo_store.py
+++ b/app/odoo_store.py
@@ -1,20 +1,30 @@
 # app/odoo_store.py
+import json
+import os
 from typing import Any, Dict, Optional
-import asyncpg, json, os
+
+import asyncpg
+
 from src.settings import ODOO_POSTGRES_DSN
+
 
 class OdooStore:
     def __init__(self, dsn: str | None = None):
         self.dsn = dsn or ODOO_POSTGRES_DSN
+        if not self.dsn:
+            raise ValueError(
+                "Odoo DSN not provided; set ODOO_POSTGRES_DSN or pass dsn."
+            )
 
     async def _acquire(self):
         return await asyncpg.connect(self.dsn)
 
-    async def upsert_company(self, name:str, uen:str|None=None, **fields) -> int:
+    async def upsert_company(self, name: str, uen: str | None = None, **fields) -> int:
         conn = await self._acquire()
         try:
             # Try update by UEN; else insert as company
-            row = await conn.fetchrow("""
+            row = await conn.fetchrow(
+                """
               UPDATE res_partner
                  SET name=$1,
                      x_uen=COALESCE($2,x_uen),
@@ -27,71 +37,121 @@ class OdooStore:
                WHERE ($2 IS NOT NULL AND x_uen=$2)
                  AND company_type='company'
                RETURNING id
-            """, name, uen, fields.get("industry_norm"), fields.get("employees_est"),
-                 fields.get("revenue_bucket"), fields.get("incorporation_year"),
-                 fields.get("website_domain"))
-            if row: return row["id"]
+            """,
+                name,
+                uen,
+                fields.get("industry_norm"),
+                fields.get("employees_est"),
+                fields.get("revenue_bucket"),
+                fields.get("incorporation_year"),
+                fields.get("website_domain"),
+            )
+            if row:
+                return row["id"]
 
-            row = await conn.fetchrow("""
+            row = await conn.fetchrow(
+                """
               INSERT INTO res_partner (name, company_type, x_uen, x_industry_norm,
                                        x_employees_est, x_revenue_bucket, x_incorporation_year, x_website_domain, create_date)
               VALUES ($1,'company',$2,$3,$4,$5,$6,$7, now())
               RETURNING id
-            """, name, uen, fields.get("industry_norm"), fields.get("employees_est"),
-                 fields.get("revenue_bucket"), fields.get("incorporation_year"), fields.get("website_domain"))
+            """,
+                name,
+                uen,
+                fields.get("industry_norm"),
+                fields.get("employees_est"),
+                fields.get("revenue_bucket"),
+                fields.get("incorporation_year"),
+                fields.get("website_domain"),
+            )
             return row["id"]
         finally:
             await conn.close()
 
-    async def add_contact(self, company_id:int, email:str, full_name:str|None=None) -> Optional[int]:
-        if not email: return None
+    async def add_contact(
+        self, company_id: int, email: str, full_name: str | None = None
+    ) -> Optional[int]:
+        if not email:
+            return None
         conn = await self._acquire()
         try:
             # dedupe by (parent_id, lower(email))
-            row = await conn.fetchrow("""
+            row = await conn.fetchrow(
+                """
               SELECT id FROM res_partner
                WHERE parent_id=$1 AND lower(email)=lower($2) LIMIT 1
-            """, company_id, email)
-            if row: return row["id"]
-            row = await conn.fetchrow("""
+            """,
+                company_id,
+                email,
+            )
+            if row:
+                return row["id"]
+            row = await conn.fetchrow(
+                """
               INSERT INTO res_partner (parent_id, company_type, name, email, create_date)
               VALUES ($1, 'person', COALESCE($3, split_part($2,'@',1)), $2, now())
               RETURNING id
-            """, company_id, email, full_name)
+            """,
+                company_id,
+                email,
+                full_name,
+            )
             return row["id"]
         finally:
             await conn.close()
 
-    async def merge_company_enrichment(self, company_id:int, enrichment:Dict[str,Any]):
+    async def merge_company_enrichment(
+        self, company_id: int, enrichment: Dict[str, Any]
+    ):
         conn = await self._acquire()
         try:
-            await conn.execute("""
+            await conn.execute(
+                """
               UPDATE res_partner
                  SET x_enrichment_json = COALESCE(x_enrichment_json,'{}'::jsonb) || $1::jsonb,
                      x_jobs_count = COALESCE($2, x_jobs_count),
                      x_tech_stack = COALESCE(x_tech_stack,'[]'::jsonb) || to_jsonb(COALESCE($3,'[]'::jsonb)),
                      write_date=now()
                WHERE id=$4 AND company_type='company'
-            """, json.dumps(enrichment),
-                 enrichment.get("jobs_count"),
-                 json.dumps(enrichment.get("tech_stack") or []),
-                 company_id)
+            """,
+                json.dumps(enrichment),
+                enrichment.get("jobs_count"),
+                json.dumps(enrichment.get("tech_stack") or []),
+                company_id,
+            )
         finally:
             await conn.close()
 
-    async def create_lead_if_high(self, company_id:int, title:str, score:float, features:Dict[str,Any], rationale:str,
-                                  primary_email:str|None, threshold:float=0.66) -> Optional[int]:
-        if score < threshold: return None
+    async def create_lead_if_high(
+        self,
+        company_id: int,
+        title: str,
+        score: float,
+        features: Dict[str, Any],
+        rationale: str,
+        primary_email: str | None,
+        threshold: float = 0.66,
+    ) -> Optional[int]:
+        if score < threshold:
+            return None
         conn = await self._acquire()
         try:
-            row = await conn.fetchrow("""
+            row = await conn.fetchrow(
+                """
               INSERT INTO crm_lead (name, partner_id, type,
                                     x_pre_sdr_score, x_pre_sdr_bucket, x_pre_sdr_features, x_pre_sdr_rationale,
                                     email_from, create_date)
               VALUES ($1,$2,'lead',$3, CASE WHEN $3>=0.66 THEN 'High' WHEN $3>=0.33 THEN 'Medium' ELSE 'Low' END,
                       $4::jsonb, $5, $6, now())
               RETURNING id
-            """, title, company_id, score, json.dumps(features), rationale, primary_email)
+            """,
+                title,
+                company_id,
+                score,
+                json.dumps(features),
+                rationale,
+                primary_email,
+            )
             return row["id"]
         finally:
             await conn.close()

--- a/read.md
+++ b/read.md
@@ -42,10 +42,12 @@ Optional / Recommended
 - TEMPERATURE: default `0.3`
 - CRAWL_MAX_PAGES: default `6` (total site pages after homepage)
 - EXTRACT_CORPUS_CHAR_LIMIT: default `35000`
+- ODOO_POSTGRES_DSN: connection string for your Odoo database; keep separate from `POSTGRES_DSN`
 
 Example `.env` (do not use real keys here)
 ```
 POSTGRES_DSN=postgres://USER:PASSWORD@HOST:5432/DB
+ODOO_POSTGRES_DSN=postgres://odoo:odoo@localhost:25060/demo
 OPENAI_API_KEY=sk-...
 TAVILY_API_KEY=tvly-...
 ZEROBOUNCE_API_KEY=zb-...
@@ -55,6 +57,35 @@ TEMPERATURE=0.3
 CRAWL_MAX_PAGES=6
 EXTRACT_CORPUS_CHAR_LIMIT=35000
 ```
+
+## Odoo Integration
+
+To extend an Odoo instance with enrichment fields, connect directly to its PostgreSQL
+database using a separate DSN. The migration script can open an SSH tunnel when the
+following variables are provided (example droplet):
+
+```
+SSH_HOST=188.166.183.13
+SSH_PORT=22
+SSH_USER=root
+SSH_PASSWORD=My_password
+DB_HOST_IN_DROPLET=172.18.0.2
+DB_PORT=5432
+DB_NAME=demo
+DB_USER=odoo
+DB_PASSWORD=odoo
+LOCAL_PORT=25060
+```
+
+Run the migration; the script will forward `LOCAL_PORT` to the droplet and build the
+DSN automatically if `ODOO_POSTGRES_DSN` isn't set:
+
+```
+python scripts/run_odoo_migration.py
+```
+
+This keeps your application database (`POSTGRES_DSN`) independent from Odoo's
+database connection.
 
 ## Database Schema & Migrations
 The code expects the following tables/columns. Adjust to your schema as needed.

--- a/src/settings.py
+++ b/src/settings.py
@@ -13,8 +13,17 @@ load_dotenv(_SRC_DIR / ".env")
 
 # Database DSN (postgres://user:pass@host:port/db)
 POSTGRES_DSN = os.getenv("POSTGRES_DSN")
-# Single source: both “app” and “odoo” use the same DSN
-ODOO_POSTGRES_DSN = POSTGRES_DSN
+# Odoo has its own DSN and does not fall back to POSTGRES_DSN
+ODOO_POSTGRES_DSN = os.getenv("ODOO_POSTGRES_DSN")
+if not ODOO_POSTGRES_DSN:
+    _local_port = os.getenv("LOCAL_PORT")
+    _db_user = os.getenv("DB_USER")
+    _db_password = os.getenv("DB_PASSWORD")
+    _db_name = os.getenv("DB_NAME")
+    if _local_port and _db_user and _db_password and _db_name:
+        ODOO_POSTGRES_DSN = (
+            f"postgresql://{_db_user}:{_db_password}@localhost:{_local_port}/{_db_name}"
+        )
 APP_POSTGRES_DSN = POSTGRES_DSN
 
 # OpenAI / LangChain config


### PR DESCRIPTION
## Summary
- allow run_odoo_migration to open an SSH tunnel using env-provided droplet credentials and build the DSN automatically
- derive Odoo DSN from local tunnel variables in settings
- document SSH variables in .env.example and README

## Testing
- `isort -v --check scripts/run_odoo_migration.py src/settings.py`
- `black --check scripts/run_odoo_migration.py src/settings.py`
- `ODOO_POSTGRES_DSN=postgresql://user:pass@localhost:1/db python scripts/run_odoo_migration.py` *(connection refused: no Postgres server)*

------
https://chatgpt.com/codex/tasks/task_e_68aedc01de288320b50678e7336e1223