### PR TITLE
Handle deterministic-only enrichment flow

### DIFF
--- a/src/enrichment.py
+++ b/src/enrichment.py
@@ -850,10 +850,18 @@ async def enrich_company_with_tavily(
     }
     try:
         final_state = await enrichment_agent.ainvoke(initial_state)
-        return final_state
     except Exception as e:
         print(f"   ↳ Enrichment graph invoke failed: {e}")
-        return initial_state
+        final_state = initial_state
+
+    extraction_ok = bool(final_state.get("extraction_success"))
+    deterministic_only = (
+        bool(final_state.get("deterministic_summary")) and not extraction_ok
+    )
+    final_state["deterministic_only"] = deterministic_only
+    final_state["enrichment_complete"] = extraction_ok or deterministic_only
+
+    return final_state
 
 
 class EnrichmentState(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- compute `enrichment_complete` flag after running enrichment graph
- route to scoring when enrichment succeeds or deterministic data is available

## Testing
- `pip install -r requirements.txt`
- `isort app/pre_sdr_graph.py src/enrichment.py`
- `black app/pre_sdr_graph.py src/enrichment.py`
- `python -m py_compile app/pre_sdr_graph.py src/enrichment.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00dcaac808320b888f7753e3a483b