### PR TITLE
feat: improve ssic search with description

### DIFF
--- a/app/migrations/007_ssic_search_indexes.sql
+++ b/app/migrations/007_ssic_search_indexes.sql
@@ -1,0 +1,6 @@
+-- Indexes to support title/description search in ssic_ref
+CREATE INDEX IF NOT EXISTS ssic_ref_title_desc_trgm_idx
+    ON ssic_ref USING gin ((title || ' ' || COALESCE(description,'')) gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS ssic_ref_title_desc_tsv_idx
+    ON ssic_ref USING gin (to_tsvector('english', title || ' ' || COALESCE(description,'')));

--- a/src/ssic_search.py
+++ b/src/ssic_search.py
@@ -85,16 +85,16 @@ def search_ssic_terms(
                     SELECT code,
                            title,
                            GREATEST(
-                               similarity(title, %s),
+                               similarity(title || ' ' || COALESCE(description,''), %s),
                                ts_rank_cd(
-                                   to_tsvector('english', title),
+                                   to_tsvector('english', title || ' ' || COALESCE(description,'')),
                                    websearch_to_tsquery('english', %s)
                                )
                            ) AS score
                     FROM ssic_ref_latest
                     WHERE (
-                          title % %s OR
-                          to_tsvector('english', title) @@ websearch_to_tsquery('english', %s)
+                          similarity(title || ' ' || COALESCE(description,''), %s) >= 0.1 OR
+                          to_tsvector('english', title || ' ' || COALESCE(description,'')) @@ websearch_to_tsquery('english', %s)
                       )
                     ORDER BY score DESC
                     LIMIT %s


### PR DESCRIPTION
## Summary
- include SSIC descriptions in trigram and full-text matching with lower similarity threshold
- add supporting indexes for combined title/description search

## Testing
- `isort src/ssic_search.py && black src/ssic_search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b35c69fc8320a715fe4099a3ced9