### PR TITLE
Use passlib for Odoo admin hashing

### DIFF
--- a/app/onboarding.py
+++ b/app/onboarding.py
@@ -2,12 +2,11 @@ import os
 import json
 import logging
 import time
-import base64
-import hashlib
 from contextlib import closing
 from typing import Optional, Tuple
 import asyncpg  # noqa: F401  # reserved for potential future async DB ops
 import requests
+from passlib.hash import pbkdf2_sha512
 from src.database import get_conn
 from app.odoo_store import OdooStore
 
@@ -843,13 +842,8 @@ def _random_password(length: int = 24) -> str:
 
 
 def _odoo_admin_hash(password: str, rounds: int = 29000) -> str:
-    """Create a pbkdf2_sha512 hash compatible with Odoo's passlib default.
-
-    Format: pbkdf2_sha512$<rounds>$<salt_b64>$<hash_b64>
-    """
-    salt = os.urandom(16)
-    dk = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), salt, rounds)
-    return f"pbkdf2_sha512${rounds}${base64.b64encode(salt).decode()}${base64.b64encode(dk).decode()}"
+    """Generate a pbkdf2_sha512 hash using passlib."""
+    return pbkdf2_sha512.hash(password, rounds=rounds)
 
 
 def _odoo_admin_dsn_for(db_name: str) -> Optional[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ langchain-tavily>=0.2.11
 tavily-python
 sse-starlette
 pydantic
+passlib

--- a/tests/test_odoo_hash.py
+++ b/tests/test_odoo_hash.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+# ensure path for import
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.onboarding import _odoo_admin_hash
+from passlib.hash import pbkdf2_sha512
+
+
+def test_odoo_admin_hash_format_and_verify():
+    pwd = "secret-password"
+    hashed = _odoo_admin_hash(pwd)
+    assert "+" not in hashed and "=" not in hashed
+    assert pbkdf2_sha512.verify(pwd, hashed)


### PR DESCRIPTION
## Summary
- switch `_odoo_admin_hash` to passlib's `pbkdf2_sha512`
- add dependency and test ensuring hash lacks `+`/`=` and verifies correctly

## Testing
- `pytest` *(fails: test_find_domain_normalizes_name_in_query, test_api_icp_by_ssic_returns_shape_and_uses_terms, test_api_icp_by_ssic_empty_terms)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f3d33cd4832085237d6510ae6e26